### PR TITLE
Fix Issue 12 - Add all project types to file dialog

### DIFF
--- a/src/ExtensionSettings.cs
+++ b/src/ExtensionSettings.cs
@@ -11,6 +11,7 @@ namespace Cyotek.VisualStudioExtensions.AddProjects
 
       public static ExtensionSettingsProjectCollection DefaultProjectTypes = new ExtensionSettingsProjectCollection
       {
+          "All Project Files|*.csproj;*.pssproj;*.vbproj;*.shproj;*.wixproj;*.exe;*.vcxproj;*.vcproj;*.dsp;*.mdp;*.props;*.vcp;*.vcxitems;*.xproj;*.jsproj;*.msbuildproj;*.vcp*.sqlproj;*.dbproj;project.json",
           "C# Projects|*.csproj",
           "Visual Basic Projects|*.vbproj",
           "C++ Projects|*.vcproj;*.vcxproj",


### PR DESCRIPTION
Hey Richard,

I just one line with all the project types. I figured I could add the specific ones, but this was good enough to get 95%. 